### PR TITLE
Unify owned and ref values [WIP]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,11 +321,11 @@ impl<Tuple: Ord> Variable<Tuple> {
     /// - Finally, you get a callback `logic` that accepts each `(SourceTuple, Val)`
     ///   that was successfully joined (and not filtered) and which maps to the
     ///   type of this variable.
-    pub fn from_leapjoin<'a, SourceTuple: Ord, Val: Ord + 'a>(
+    pub fn from_leapjoin<SourceTuple: Ord, Val: Ord>(
         &self,
         source: &Variable<SourceTuple>,
-        leapers: &mut [&mut dyn Leaper<SourceTuple, &'a Val>],
-        logic: impl FnMut(&SourceTuple, &Val) -> Tuple,
+        leapers: &mut [&mut dyn Leaper<SourceTuple, Val>],
+        logic: impl FnMut(&SourceTuple, Val) -> Tuple,
     ) {
         treefrog::leapjoin_into(source, leapers, self, logic)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ impl<Tuple: Ord> Variable<Tuple> {
     pub fn from_leapjoin<'a, SourceTuple: Ord, Val: Ord + 'a>(
         &self,
         source: &Variable<SourceTuple>,
-        leapers: &mut [&mut dyn Leaper<'a, SourceTuple, Val>],
+        leapers: &mut [&mut dyn Leaper<SourceTuple, &'a Val>],
         logic: impl FnMut(&SourceTuple, &Val) -> Tuple,
     ) {
         treefrog::leapjoin_into(source, leapers, self, logic)

--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -298,7 +298,7 @@ pub(crate) mod extend_anti {
         }
     }
 
-    impl<'a, Key: Ord, Val: Ord + 'a, Tuple: Ord, Func: Fn(&Tuple) -> Key> Leaper<Tuple, Val>
+    impl<'a, Key, Val, Tuple, Func> Leaper<Tuple, Val>
         for ExtendAnti<'a, Key, Val, Tuple, Func>
     where
         Key: Ord + 'a,

--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -176,8 +176,7 @@ pub(crate) mod extend_with {
         }
     }
 
-    impl<'a, Key, Val, Tuple, Func> Leaper<Tuple, &'a Val>
-        for ExtendWith<'a, Key, Val, Tuple, Func>
+    impl<'a, Key, Val, Tuple, Func> Leaper<Tuple, &'a Val> for ExtendWith<'a, Key, Val, Tuple, Func>
     where
         Key: Ord + 'a,
         Val: Ord + 'a,
@@ -205,8 +204,7 @@ pub(crate) mod extend_with {
         }
     }
 
-    impl<'a, Key, Val, Tuple, Func> Leaper<Tuple, Val>
-        for ExtendWith<'a, Key, Val, Tuple, Func>
+    impl<'a, Key, Val, Tuple, Func> Leaper<Tuple, Val> for ExtendWith<'a, Key, Val, Tuple, Func>
     where
         Key: Ord + 'a,
         Val: Ord + Clone + 'a,
@@ -269,8 +267,7 @@ pub(crate) mod extend_anti {
         }
     }
 
-    impl<'a, Key, Val, Tuple, Func> Leaper<Tuple, &'a Val>
-        for ExtendAnti<'a, Key, Val, Tuple, Func>
+    impl<'a, Key, Val, Tuple, Func> Leaper<Tuple, &'a Val> for ExtendAnti<'a, Key, Val, Tuple, Func>
     where
         Key: Ord + 'a,
         Val: Ord + 'a,
@@ -298,8 +295,7 @@ pub(crate) mod extend_anti {
         }
     }
 
-    impl<'a, Key, Val, Tuple, Func> Leaper<Tuple, Val>
-        for ExtendAnti<'a, Key, Val, Tuple, Func>
+    impl<'a, Key, Val, Tuple, Func> Leaper<Tuple, Val> for ExtendAnti<'a, Key, Val, Tuple, Func>
     where
         Key: Ord + 'a,
         Val: Ord + Clone + 'a,
@@ -362,8 +358,7 @@ pub(crate) mod filter_with {
         }
     }
 
-    impl<'a, Key, Val, Val2, Tuple, Func> Leaper<Tuple, Val2>
-        for FilterWith<'a, Key, Val, Tuple, Func>
+    impl<'a, Key, Val, Val2, Tuple, Func> Leaper<Tuple, Val2> for FilterWith<'a, Key, Val, Tuple, Func>
     where
         Key: Ord + 'a,
         Val: Ord + 'a,
@@ -421,8 +416,7 @@ pub(crate) mod filter_anti {
         }
     }
 
-    impl<'a, Key, Val, Val2, Tuple, Func> Leaper<Tuple, Val2>
-        for FilterAnti<'a, Key, Val, Tuple, Func>
+    impl<'a, Key, Val, Val2, Tuple, Func> Leaper<Tuple, Val2> for FilterAnti<'a, Key, Val, Tuple, Func>
     where
         Key: Ord + 'a,
         Val: Ord + 'a,

--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -269,7 +269,7 @@ pub(crate) mod extend_anti {
         }
     }
 
-    impl<'a, Key: Ord, Val: Ord + 'a, Tuple: Ord, Func: Fn(&Tuple) -> Key> Leaper<Tuple, &'a Val>
+    impl<'a, Key, Val, Tuple, Func> Leaper<Tuple, &'a Val>
         for ExtendAnti<'a, Key, Val, Tuple, Func>
     where
         Key: Ord + 'a,


### PR DESCRIPTION
This PR attempts to unify treefrog implementations to work both with owned and reference value types.

Previously, the signatures of the `Leaper` trait involved `Leaper<'a, Tuple, Val: 'a>` and spoke of vectors of `&'a Val` elements. These references are potentially unnecessarily complicated if `Val` is simple and supports clone, so we change this to be 

```rust
/// Methods to support treefrog leapjoin.
pub trait Leaper<Tuple, Val> {
    /// Estimates the number of proposed values.
    fn count(&mut self, prefix: &Tuple) -> usize;
    /// Populates `values` with proposed values.
    fn propose(&mut self, prefix: &Tuple, values: &mut Vec<Val>);
    /// Restricts `values` to proposed values.
    fn intersect(&mut self, prefix: &Tuple, values: &mut Vec<Val>);
}
```

Where the `Val` type can be arbitrary. Now, we have multiple implementations of `Leaper` where appropriate, both

```
    impl<'a, Key, Val, Tuple, Func> Leaper<Tuple, &'a Val> for ...
    impl<'a, Key, Val, Tuple, Func> Leaper<Tuple, Val> for ... 
```

The `FilterWith` and `FilterAnti` variants had no constraint on their `Val` type, and so we just removed the requirement that it be a reference and got a more general implementation (yay). Neither looks at the value field, and just makes their decision based on the key parts of the record.

The potential fall-out is that there are now multiple implementations of `Leaper`, and it may be less obvious which is intended when you casually try to `leapjoin_into`. 

The `from_leapjoin` method on `Variable` now has the signature

```rust
    pub fn from_leapjoin<SourceTuple: Ord, Val: Ord>(
        &self,
        source: &Variable<SourceTuple>,
        leapers: &mut [&mut dyn Leaper<SourceTuple, Val>],
        logic: impl FnMut(&SourceTuple, Val) -> Tuple,
    )
```

which allows `Val` to be `&'a Val` as appropriate, or `Val`, and it is an open question whether this will allow anyone to actually use this elegantly.