### PR TITLE
Micro-optimize `binary_search`

### DIFF
--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -650,7 +650,8 @@ fn binary_search<T>(slice: &[T], mut cmp: impl FnMut(&T) -> bool) -> usize {
     let mut lo = 0;
     while lo < hi {
         let mid = lo + (hi - lo) / 2;
-        if cmp(&slice[mid]) {
+        let el: &T = unsafe { slice.get_unchecked(mid) };
+        if cmp(el) {
             lo = mid + 1;
         } else {
             hi = mid;

--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -362,7 +362,7 @@ pub(crate) mod extend_with {
     {
         fn count(&mut self, prefix: &Tuple) -> usize {
             let key = (self.key_func)(prefix);
-            self.start = binary_search(&self.relation[..], |x| &x.0 < &key);
+            self.start = binary_search(&self.relation.elements, |x| &x.0 < &key);
             let slice1 = &self.relation[self.start..];
             let slice2 = gallop(slice1, |x| &x.0 <= &key);
             self.end = self.relation.len() - slice2.len();
@@ -454,7 +454,7 @@ pub(crate) mod extend_anti {
         }
         fn intersect(&mut self, prefix: &Tuple, values: &mut Vec<&'leap Val>) {
             let key = (self.key_func)(prefix);
-            let start = binary_search(&self.relation[..], |x| &x.0 < &key);
+            let start = binary_search(&self.relation.elements, |x| &x.0 < &key);
             let slice1 = &self.relation[start..];
             let slice2 = gallop(slice1, |x| &x.0 <= &key);
             let mut slice = &slice1[..(slice1.len() - slice2.len())];
@@ -642,15 +642,32 @@ pub(crate) mod filter_anti {
     }
 }
 
-fn binary_search<T>(slice: &[T], mut cmp: impl FnMut(&T) -> bool) -> usize {
+/// Returns the lowest index for which `cmp(&vec[i])` returns `true`, assuming `vec` is in sorted
+/// order.
+///
+/// By accepting a vector instead of a slice, we can do a small optimization when computing the
+/// midpoint.
+fn binary_search<T>(vec: &Vec<T>, mut cmp: impl FnMut(&T) -> bool) -> usize {
+    // The midpoint calculation we use below is only correct for vectors with less than `isize::MAX`
+    // elements. This is always true for vectors of sized types but maybe not for ZSTs? Sorting
+    // ZSTs doesn't make much sense, so just forbid it here.
+    assert!(std::mem::size_of::<T>() > 0);
+
     // we maintain the invariant that `lo` many elements of `slice` satisfy `cmp`.
     // `hi` is maintained at the first element we know does not satisfy `cmp`.
 
-    let mut hi = slice.len();
+    let mut hi = vec.len();
     let mut lo = 0;
     while lo < hi {
-        let mid = lo + (hi - lo) / 2;
-        let el: &T = unsafe { slice.get_unchecked(mid) };
+        // Unlike in the general case, this expression cannot overflow because `Vec` is limited to
+        // `isize::MAX` capacity and we disallow ZSTs above. If we needed to support slices or
+        // vectors of ZSTs, which don't have an upper bound on their size AFAIK, we would need to
+        // use a slightly less efficient version that cannot overflow: `lo + (hi - lo) / 2`.
+        let mid = (hi + lo) / 2;
+
+        // LLVM seems to be unable to prove that `mid` is always less than `vec.len()`, so use
+        // `get_unchecked` to avoid a bounds check since this code is hot.
+        let el: &T = unsafe { vec.get_unchecked(mid) };
         if cmp(el) {
             lo = mid + 1;
         } else {

--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -233,7 +233,6 @@ pub(crate) mod filters {
             values.retain(|val| (self.predicate)(prefix, val));
         }
     }
-
 }
 
 /// Extension method for relations.


### PR DESCRIPTION
We spend about 30% of cycles doing binary search in [`ExtendWith::count`](https://github.com/rust-lang/datafrog/blob/883f028f29436cd4df62f6a2f77b8c75b5f52235/src/treefrog.rs#L364-L371) while running `clap-rs/app-parser-{{impl}}-add_defaults`. This indicates to me that we need to explore different storage for the `cfg_edge` relation, but a maximally optimal `binary_search` is beneficial regardless.

This PR switches to `get_unchecked` to eliminate a bounds check that the optimizer cannot. This is also done in the [standard library implementation](https://github.com/rust-lang/rust/blob/507bff92fadf1f25a830da5065a5a87113345163/library/core/src/slice/mod.rs#L1930).

It also takes advantage of a lesser known invariant of `Vec`, that the capacity [cannot exceed `isize::MAX` bytes](https://doc.rust-lang.org/std/vec/struct.Vec.html#panics), to compute the midpoint using less instructions (there's a [fun article](https://ai.googleblog.com/2006/06/extra-extra-read-all-about-it-nearly.html) from the early internet about this). 

As a result, the aforementioned test case on a Ryzen 4700U laptop on a goes from this:

```
 Performance counter stats for 'target/release/polonius -a DatafrogOpt inputs/clap-rs/app-parser-{{impl}}-add_defaults':

   691,011,608,622      instructions:u                                              

      99.967872602 seconds time elapsed

      96.724862000 seconds user
       3.172634000 seconds sys
```

to this:

```
 Performance counter stats for 'target/release/polonius -a DatafrogOpt inputs/clap-rs/app-parser-{{impl}}-add_defaults':

   623,280,710,902      instructions:u                                              

      92.983953355 seconds time elapsed

      89.483132000 seconds user
       3.404928000 seconds sys
```

Wall time is highly variable and may differ on your platform.

cc @shepmaster (since they seem to be interested in this sort of thing)