### PR TITLE
Support arbitrary tuples

### DIFF
--- a/src/join.rs
+++ b/src/join.rs
@@ -15,6 +15,50 @@ pub(crate) fn join_into<'me, Key: Ord, Value1: Ord, Value2: Ord, Result: Ord>(
     output: &Variable<Result>,
     mut logic: impl FnMut(&Key, &Value1, &Value2) -> Result,
 ) {
+    join_into_by_impl(
+        input1,
+        input2,
+        output,
+        |(key, _value)| key,
+        |(key, _value)| key,
+        |tuple1, tuple2| logic(&tuple1.0, &tuple1.1, &tuple2.1),
+    )
+}
+
+pub(crate) fn join_into_by<
+    'me,
+    Key: Ord,
+    Tuple1: Ord,
+    Tuple2: Ord,
+    Accessor1,
+    Accessor2,
+    Result: Ord,
+>(
+    input1: &Variable<Tuple1>,
+    input2: impl JoinInput<'me, Tuple2>,
+    output: &Variable<Result>,
+    accessor1: Accessor1,
+    accessor2: Accessor2,
+    logic: impl FnMut(&Tuple1, &Tuple2) -> Result,
+) where
+    Accessor1: Fn(&Tuple1) -> &Key,
+    Accessor2: Fn(&Tuple2) -> &Key,
+{
+    join_into_by_impl(input1, input2, output, accessor1, accessor2, logic)
+}
+
+#[inline(always)]
+fn join_into_by_impl<'me, Key: Ord, Tuple1: Ord, Tuple2: Ord, Accessor1, Accessor2, Result: Ord>(
+    input1: &Variable<Tuple1>,
+    input2: impl JoinInput<'me, Tuple2>,
+    output: &Variable<Result>,
+    accessor1: Accessor1,
+    accessor2: Accessor2,
+    mut logic: impl FnMut(&Tuple1, &Tuple2) -> Result,
+) where
+    Accessor1: Fn(&Tuple1) -> &Key,
+    Accessor2: Fn(&Tuple2) -> &Key,
+{
     let mut results = Vec::new();
 
     let recent1 = input1.recent();
@@ -23,17 +67,17 @@ pub(crate) fn join_into<'me, Key: Ord, Value1: Ord, Value2: Ord, Result: Ord>(
     {
         // scoped to let `closure` drop borrow of `results`.
 
-        let mut closure = |k: &Key, v1: &Value1, v2: &Value2| results.push(logic(k, v1, v2));
+        let mut closure = |tuple1: &Tuple1, tuple2: &Tuple2| results.push(logic(tuple1, tuple2));
 
         for batch2 in input2.stable().iter() {
-            join_helper(&recent1, &batch2, &mut closure);
+            join_helper_by(&recent1, &batch2, &accessor1, &accessor2, &mut closure);
         }
 
         for batch1 in input1.stable().iter() {
-            join_helper(&batch1, &recent2, &mut closure);
+            join_helper_by(&batch1, &recent2, &accessor1, &accessor2, &mut closure);
         }
 
-        join_helper(&recent1, &recent2, &mut closure);
+        join_helper_by(&recent1, &recent2, &accessor1, &accessor2, &mut closure);
     }
 
     output.insert(Relation::from_vec(results));
@@ -45,58 +89,188 @@ pub(crate) fn join_into_relation<'me, Key: Ord, Value1: Ord, Value2: Ord, Result
     input2: &Relation<(Key, Value2)>,
     mut logic: impl FnMut(&Key, &Value1, &Value2) -> Result,
 ) -> Relation<Result> {
+    join_into_relation_by(
+        input1,
+        input2,
+        |(key, _value)| key,
+        |(key, _value)| key,
+        |tuple1, tuple2| logic(&tuple1.0, &tuple1.1, &tuple2.1),
+    )
+}
+
+/// Join, but for two relations.
+pub(crate) fn join_into_relation_by<
+    'me,
+    Key: Ord,
+    Tuple1: Ord,
+    Tuple2: Ord,
+    Accessor1,
+    Accessor2,
+    Result: Ord,
+>(
+    input1: &Relation<Tuple1>,
+    input2: &Relation<Tuple2>,
+    accessor1: Accessor1,
+    accessor2: Accessor2,
+    mut logic: impl FnMut(&Tuple1, &Tuple2) -> Result,
+) -> Relation<Result>
+where
+    Accessor1: Fn(&Tuple1) -> &Key,
+    Accessor2: Fn(&Tuple2) -> &Key,
+{
     let mut results = Vec::new();
 
-    join_helper(&input1.elements, &input2.elements, |k, v1, v2| {
-        results.push(logic(k, v1, v2));
-    });
+    join_helper_by(
+        &input1.elements,
+        &input2.elements,
+        &accessor1,
+        &accessor2,
+        |tuple1, tuple2| {
+            results.push(logic(tuple1, tuple2));
+        },
+    );
 
     Relation::from_vec(results)
 }
 
 /// Moves all recent tuples from `input1` that are not present in `input2` into `output`.
-pub(crate) fn antijoin<'me, Key: Ord, Val: Ord, Result: Ord>(
-    input1: impl JoinInput<'me, (Key, Val)>,
+pub(crate) fn antijoin<'me, Key: Ord, Value1: Ord, Result: Ord>(
+    input1: impl JoinInput<'me, (Key, Value1)>,
     input2: &Relation<Key>,
-    mut logic: impl FnMut(&Key, &Val) -> Result,
+    mut logic: impl FnMut(&Key, &Value1) -> Result,
 ) -> Relation<Result> {
+    antijoin_by_impl(
+        input1,
+        input2,
+        |(key, _value)| key,
+        |key| key,
+        |(key, value)| logic(key, value),
+    )
+}
+
+pub(crate) fn antijoin_by<
+    'me,
+    Tuple1: Ord,
+    Tuple2: Ord,
+    Key: Ord,
+    Accessor1,
+    Accessor2,
+    Result: Ord,
+>(
+    input1: impl JoinInput<'me, Tuple1>,
+    input2: &Relation<Tuple2>,
+    accessor1: Accessor1,
+    accessor2: Accessor2,
+    logic: impl FnMut(&Tuple1) -> Result,
+) -> Relation<Result>
+where
+    Accessor1: Fn(&Tuple1) -> &Key,
+    Accessor2: Fn(&Tuple2) -> &Key,
+{
+    antijoin_by_impl(input1, input2, accessor1, accessor2, logic)
+}
+
+/// Moves all recent tuples from `input1` that are not present in `input2` into `output`.
+#[inline(always)]
+pub(crate) fn antijoin_by_impl<
+    'me,
+    Tuple1: Ord,
+    Tuple2: Ord,
+    Key: Ord,
+    Accessor1,
+    Accessor2,
+    Result: Ord,
+>(
+    input1: impl JoinInput<'me, Tuple1>,
+    input2: &Relation<Tuple2>,
+    accessor1: Accessor1,
+    accessor2: Accessor2,
+    mut logic: impl FnMut(&Tuple1) -> Result,
+) -> Relation<Result>
+where
+    Accessor1: Fn(&Tuple1) -> &Key,
+    Accessor2: Fn(&Tuple2) -> &Key,
+{
     let mut tuples2 = &input2[..];
 
     let results = input1
         .recent()
         .iter()
-        .filter(|(ref key, _)| {
-            tuples2 = gallop(tuples2, |k| k < key);
-            tuples2.first() != Some(key)
+        .filter(|tuple| {
+            let key = accessor1(tuple);
+            tuples2 = gallop(tuples2, |k| accessor2(k) < key);
+            tuples2.first().map(|tuple2| accessor2(tuple2)) != Some(key)
         })
-        .map(|(ref key, ref val)| logic(key, val))
+        .map(|tuple| logic(tuple))
         .collect::<Vec<_>>();
 
     Relation::from_vec(results)
 }
 
+#[allow(dead_code)]
 fn join_helper<Key: Ord, Value1, Value2>(
-    mut slice1: &[(Key, Value1)],
-    mut slice2: &[(Key, Value2)],
+    slice1: &[(Key, Value1)],
+    slice2: &[(Key, Value2)],
     mut result: impl FnMut(&Key, &Value1, &Value2),
 ) {
+    join_helper_by_impl(
+        slice1,
+        slice2,
+        |(key, _value)| key,
+        |(key, _value)| key,
+        |tuple1, tuple2| result(&tuple1.0, &tuple1.1, &tuple2.1),
+    )
+}
+
+fn join_helper_by<Key: Ord, Tuple1, Tuple2, Accessor1, Accessor2>(
+    slice1: &[Tuple1],
+    slice2: &[Tuple2],
+    accessor1: Accessor1,
+    accessor2: Accessor2,
+    result: impl FnMut(&Tuple1, &Tuple2),
+) where
+    Accessor1: Fn(&Tuple1) -> &Key,
+    Accessor2: Fn(&Tuple2) -> &Key,
+{
+    join_helper_by_impl(slice1, slice2, accessor1, accessor2, result)
+}
+
+#[inline(always)]
+fn join_helper_by_impl<Key: Ord, Tuple1, Tuple2, Accessor1, Accessor2>(
+    mut slice1: &[Tuple1],
+    mut slice2: &[Tuple2],
+    accessor1: Accessor1,
+    accessor2: Accessor2,
+    mut result: impl FnMut(&Tuple1, &Tuple2),
+) where
+    Accessor1: Fn(&Tuple1) -> &Key,
+    Accessor2: Fn(&Tuple2) -> &Key,
+{
     while !slice1.is_empty() && !slice2.is_empty() {
         use std::cmp::Ordering;
 
+        let ordering = { accessor1(&slice1[0]).cmp(&accessor2(&slice2[0])) };
+
         // If the keys match produce tuples, else advance the smaller key until they might.
-        match slice1[0].0.cmp(&slice2[0].0) {
+        match ordering {
             Ordering::Less => {
-                slice1 = gallop(slice1, |x| x.0 < slice2[0].0);
+                slice1 = gallop(slice1, |x| accessor1(x) < accessor2(&slice2[0]));
             }
             Ordering::Equal => {
                 // Determine the number of matching keys in each slice.
-                let count1 = slice1.iter().take_while(|x| x.0 == slice1[0].0).count();
-                let count2 = slice2.iter().take_while(|x| x.0 == slice2[0].0).count();
+                let count1 = slice1
+                    .iter()
+                    .take_while(|x| accessor1(x) == accessor1(&slice1[0]))
+                    .count();
+                let count2 = slice2
+                    .iter()
+                    .take_while(|x| accessor2(x) == accessor2(&slice2[0]))
+                    .count();
 
                 // Produce results from the cross-product of matches.
                 for index1 in 0..count1 {
                     for s2 in slice2[..count2].iter() {
-                        result(&slice1[0].0, &slice1[index1].1, &s2.1);
+                        result(&slice1[index1], s2);
                     }
                 }
 
@@ -105,7 +279,7 @@ fn join_helper<Key: Ord, Value1, Value2>(
                 slice2 = &slice2[count2..];
             }
             Ordering::Greater => {
-                slice2 = gallop(slice2, |x| x.0 < slice1[0].0);
+                slice2 = gallop(slice2, |x| accessor2(x) < accessor1(&slice1[0]));
             }
         }
     }

--- a/src/map.rs
+++ b/src/map.rs
@@ -2,12 +2,12 @@
 
 use super::{Relation, Variable};
 
-pub(crate) fn map_into<T1: Ord, T2: Ord>(
-    input: &Variable<T1>,
-    output: &Variable<T2>,
-    logic: impl FnMut(&T1) -> T2,
+pub(crate) fn map_into<Tuple1: Ord, Tuple2: Ord>(
+    input: &Variable<Tuple1>,
+    output: &Variable<Tuple2>,
+    logic: impl FnMut(&Tuple1) -> Tuple2,
 ) {
-    let results: Vec<T2> = input.recent.borrow().iter().map(logic).collect();
+    let results: Vec<Tuple2> = input.recent.borrow().iter().map(logic).collect();
 
     output.insert(Relation::from_vec(results));
 }

--- a/src/relation.rs
+++ b/src/relation.rs
@@ -48,10 +48,10 @@ impl<Tuple: Ord> Relation<Tuple> {
     /// `input2` and then applying `logic`. Like
     /// [`Variable::from_join`] except for use where the inputs are
     /// not varying across iterations.
-    pub fn from_join<Key: Ord, Val1: Ord, Val2: Ord>(
-        input1: &Relation<(Key, Val1)>,
-        input2: &Relation<(Key, Val2)>,
-        logic: impl FnMut(&Key, &Val1, &Val2) -> Tuple,
+    pub fn from_join<Key: Ord, Value1: Ord, Value2: Ord>(
+        input1: &Relation<(Key, Value1)>,
+        input2: &Relation<(Key, Value2)>,
+        logic: impl FnMut(&Key, &Value1, &Value2) -> Tuple,
     ) -> Self {
         join::join_into_relation(input1, input2, logic)
     }
@@ -61,10 +61,10 @@ impl<Tuple: Ord> Relation<Tuple> {
     /// tuples with the `logic` closure. Like
     /// [`Variable::from_antijoin`] except for use where the inputs
     /// are not varying across iterations.
-    pub fn from_antijoin<Key: Ord, Val1: Ord>(
-        input1: &Relation<(Key, Val1)>,
+    pub fn from_antijoin<Key: Ord, Value1: Ord>(
+        input1: &Relation<(Key, Value1)>,
         input2: &Relation<Key>,
-        logic: impl FnMut(&Key, &Val1) -> Tuple,
+        logic: impl FnMut(&Key, &Value1) -> Tuple,
     ) -> Self {
         join::antijoin(input1, input2, logic)
     }
@@ -72,7 +72,10 @@ impl<Tuple: Ord> Relation<Tuple> {
     /// Construct a new relation by mapping another one. Equivalent to
     /// creating an iterator but perhaps more convenient. Analogous to
     /// `Variable::from_map`.
-    pub fn from_map<T2: Ord>(input: &Relation<T2>, logic: impl FnMut(&T2) -> Tuple) -> Self {
+    pub fn from_map<Tuple2: Ord>(
+        input: &Relation<Tuple2>,
+        logic: impl FnMut(&Tuple2) -> Tuple,
+    ) -> Self {
         input.iter().map(logic).collect()
     }
 

--- a/src/relation.rs
+++ b/src/relation.rs
@@ -56,6 +56,24 @@ impl<Tuple: Ord> Relation<Tuple> {
         join::join_into_relation(input1, input2, logic)
     }
 
+    /// Creates a `Relation` by joining the values from `input1` and
+    /// `input2`, through `accessor1` and `accessor2` respectively, and then applying `logic`. Like
+    /// [`Variable::from_join_by`] except for use where the inputs are
+    /// not varying across iterations.
+    pub fn from_join_by<Key: Ord, Tuple1: Ord, Tuple2: Ord, Accessor1, Accessor2>(
+        input1: &Relation<Tuple1>,
+        input2: &Relation<Tuple2>,
+        accessor1: Accessor1,
+        accessor2: Accessor2,
+        logic: impl FnMut(&Tuple1, &Tuple2) -> Tuple,
+    ) -> Self
+    where
+        Accessor1: Fn(&Tuple1) -> &Key,
+        Accessor2: Fn(&Tuple2) -> &Key,
+    {
+        join::join_into_relation_by(input1, input2, accessor1, accessor2, logic)
+    }
+
     /// Creates a `Relation` by removing all values from `input1` that
     /// share a key with `input2`, and then transforming the resulting
     /// tuples with the `logic` closure. Like
@@ -67,6 +85,25 @@ impl<Tuple: Ord> Relation<Tuple> {
         logic: impl FnMut(&Key, &Value1) -> Tuple,
     ) -> Self {
         join::antijoin(input1, input2, logic)
+    }
+
+    /// Creates a `Relation` by removing all values from `input1` that
+    /// share a key with `input2`, through `accessor1` and `accessor2` respectively,
+    /// and then transforming the resulting tuples with the `logic` closure.
+    /// Like [`Variable::from_antijoin_by`] except for use where the inputs
+    /// are not varying across iterations.
+    pub fn from_antijoin_by<Key: Ord, Tuple1: Ord, Tuple2: Ord, Accessor1, Accessor2>(
+        input1: &Relation<Tuple1>,
+        input2: &Relation<Tuple2>,
+        accessor1: Accessor1,
+        accessor2: Accessor2,
+        logic: impl FnMut(&Tuple1) -> Tuple,
+    ) -> Self
+    where
+        Accessor1: Fn(&Tuple1) -> &Key,
+        Accessor2: Fn(&Tuple2) -> &Key,
+    {
+        join::antijoin_by(input1, input2, accessor1, accessor2, logic)
     }
 
     /// Construct a new relation by mapping another one. Equivalent to

--- a/src/test.rs
+++ b/src/test.rs
@@ -86,7 +86,7 @@ fn sum_join_via_var(
     let output = iteration.variable::<(u32, u32)>("output");
 
     while iteration.changed() {
-        // output(K1, V1 * 100 + V2) :- input1(K1, V1), input2(K1, V2).
+        // output(K1, Value1 * 100 + Value2) :- input1(K1, Value1), input2(K1, Value2).
         output.from_join(&input1, &input2, |&k1, &v1, &v2| (k1, v1 * 100 + v2));
     }
 

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -53,8 +53,8 @@ pub struct Variable<Tuple: Ord> {
 impl<Tuple: Ord> Variable<Tuple> {
     /// Adds tuples that result from joining `input1` and `input2` --
     /// each of the inputs must be a set of (Key, Value) tuples. Both
-    /// `input1` and `input2` must have the same type of key (`K`) but
-    /// they can have distinct value types (`V1` and `V2`
+    /// `input1` and `input2` must have the same type of key (`Key`) but
+    /// they can have distinct value types (`Value1` and `Value2`
     /// respectively). The `logic` closure will be invoked for each
     /// key that appears in both inputs; it is also given the two
     /// values, and from those it should construct the resulting
@@ -89,11 +89,11 @@ impl<Tuple: Ord> Variable<Tuple> {
     /// let result = variable.complete();
     /// assert_eq!(result.len(), 121);
     /// ```
-    pub fn from_join<'me, K: Ord, V1: Ord, V2: Ord>(
+    pub fn from_join<'me, Key: Ord, Value1: Ord, Value2: Ord>(
         &self,
-        input1: &'me Variable<(K, V1)>,
-        input2: impl JoinInput<'me, (K, V2)>,
-        logic: impl FnMut(&K, &V1, &V2) -> Tuple,
+        input1: &'me Variable<(Key, Value1)>,
+        input2: impl JoinInput<'me, (Key, Value2)>,
+        logic: impl FnMut(&Key, &Value1, &Value2) -> Tuple,
     ) {
         join::join_into(input1, input2, self, logic)
     }
@@ -127,11 +127,11 @@ impl<Tuple: Ord> Variable<Tuple> {
     /// let result = variable.complete();
     /// assert_eq!(result.len(), 16);
     /// ```
-    pub fn from_antijoin<K: Ord, V: Ord>(
+    pub fn from_antijoin<Key: Ord, Value: Ord>(
         &self,
-        input1: &Variable<(K, V)>,
-        input2: &Relation<K>,
-        logic: impl FnMut(&K, &V) -> Tuple,
+        input1: &Variable<(Key, Value)>,
+        input2: &Relation<Key>,
+        logic: impl FnMut(&Key, &Value) -> Tuple,
     ) {
         self.insert(join::antijoin(input1, input2, logic))
     }
@@ -165,7 +165,11 @@ impl<Tuple: Ord> Variable<Tuple> {
     /// let result = variable.complete();
     /// assert_eq!(result.len(), 74);
     /// ```
-    pub fn from_map<T2: Ord>(&self, input: &Variable<T2>, logic: impl FnMut(&T2) -> Tuple) {
+    pub fn from_map<Tuple2: Ord>(
+        &self,
+        input: &Variable<Tuple2>,
+        logic: impl FnMut(&Tuple2) -> Tuple,
+    ) {
         map::map_into(input, self, logic)
     }
 
@@ -185,14 +189,14 @@ impl<Tuple: Ord> Variable<Tuple> {
     ///   `leapers`, each of which is derived from a fixed relation. The `leapers`
     ///   should be either a single leaper (of suitable type) or else a tuple of leapers.
     ///   You can create a leaper in one of two ways:
-    ///   - Extension: In this case, you have a relation of type `(K, Val)` for some
-    ///     type `K`. You provide a closure that maps from `SourceTuple` to the key
-    ///     `K`. If you use `relation.extend_with`, then any `Val` values the
+    ///   - Extension: In this case, you have a relation of type `(Key, Val)` for some
+    ///     type `Key`. You provide a closure that maps from `SourceTuple` to the key
+    ///     `Key`. If you use `relation.extend_with`, then any `Val` values the
     ///     relation provides will be added to the set of values; if you use
     ///     `extend_anti`, then the `Val` values will be removed.
-    ///   - Filtering: In this case, you have a relation of type `K` for some
-    ///     type `K` and you provide a closure that maps from `SourceTuple` to
-    ///     the key `K`. Filters don't provide values but they remove source
+    ///   - Filtering: In this case, you have a relation of type `Key` for some
+    ///     type `Key` and you provide a closure that maps from `SourceTuple` to
+    ///     the key `Key`. Filters don't provide values but they remove source
     ///     tuples.
     /// - Finally, you get a callback `logic` that accepts each `(SourceTuple, Val)`
     ///   that was successfully joined (and not filtered) and which maps to the


### PR DESCRIPTION
This PR aims to make `datafrog` less dependent on`(Key, Value)` tuples, lessening the burden of having to create lots and lots of intermediary variables that do little more than move an element to the front of the tuple, so it can be used as key.

# Before

As such where you currently have to introduce auxiliary variables of `(Key, Value)` tuples:

```rust
let variable: Variable<(f32, i32, bool)> = …;
let relation: Relation<(u8, i32)> = …;

// Auxiliary variables/relations:
let auxiliary_variable: Variable<(i32, (f32, bool))> = …;
let auxiliary_relation: Relation<(i32, u8)> = …;

let result_variable = iteration.variable::<(u8, bool)>("(u8, bool)");

while iteration.changed() {
    // Additional maintenance for auxiliary variables:
    auxiliary_variable.from_map(&variable, |tuple|
        (tuple.1, tuple.0)
    );
    auxiliary_relation.from_map(&relation, |tuple|
        (tuple.1, tuple.0)
    );

    result_variable.from_join(
        &auxiliary_variable,
        &auxiliary_relation,
        |_, (_, boolean1), (_, byte2)| (byte2, boolean1),
    );
}
```

# After

… with this PR you simply extract the key from an arbitrary tuple index using a closure:

```rust
let variable: Variable<(f32, i32, bool)> = …;
let relation: Relation<(u8, i32)> = …;

let result_variable = iteration.variable::<(u8, bool)>("(u8, bool)");

while iteration.changed() {
    result_variable.from_join_by(
        &variable,
        &relation,
        |(_, integer, _)| integer,
        |(_, integer)| integer,
        |(_, _, boolean1), (byte2, _)| (byte2, boolean1),
    );
}
```

This cuts down the maintenance burden of having to keep several additional auxiliary variables and relations up-to-date, reducing the mental overhead and brings your datafrog Rust code a little bit closer to their corresponding datalog rules.

@frankmcsherry @nikomatsakis I hope that these changes are not in conflict with the soundness of the API of datafrog or the semantics of Datalog?

# Performance

I did some performance testing with criterion, but did not find any consistent and noteworthy performance regressions for existing APIs and found the overhead of the `…_by` method variants minimal.

# Known limitations

Unfortunately this PR only allows lenses to return references to arbitrary elements of the tuple (via `Accessor1: Fn(&Tuple1) -> &Key`), but no owned ad-hoc values.

I had initially hoped to be able to allow for arbitrary Key values, such as ad-hoc tuples or other computed values. This would have allowed for a returning `(&X, &Y)` as key for `(X, Y, Z)` tuple, rather than just single individual elements of it. Support for arbitrary tuples as keys would have been very convenient for scenarios with complex n-ary keys such as [borrow_check.rs](https://github.com/rust-lang/datafrog/blob/master/examples/borrow_check.rs).

Changing `Accessor1: Fn(&Tuple1) -> &Key,` to `Accessor1: Fn(&Tuple1) -> Key,` unfortunately causes accessors that return a reference to the tuple or elements of it, such as `|tuple| &tuple` or `|tuple| &tuple.0` to trigger [this](https://github.com/rust-lang/rust/issues/56537) language limitation. Unfortunately those are the most commonly used accessors and I'm not aware of a workaround that would allow both, arbitrary keys _and_ borrowed tuple element keys.

<details>

<summary>Minimal reproducible snippet </summary>

```rust
fn dummy<'a, T, K: 'a, F>(value: &'a T, f: F) -> K
where
    F: Fn(&T) -> K
{
    f(value)
}

fn main() {
    let tuple = (1, 2, 3);
    let _ = dummy(&tuple, |tuple| &tuple.0);
}
```

Error:
```
10 |     let _ = dummy(&tuple, |tuple| &tuple.0);
   |                            ------ ^^^^^^^^ returning this value requires that `'1` must outlive `'2`
   |                            |    |
   |                            |    return type of closure is &'2 i32
   |                            has type `&'1 (i32, i32, i32)`
```

</details>

---

This is part #3 of a stacked pull-request and adds upon #33:

```
└── Split-up\ lib.rs (#32)
    └── Cleanup\ generics (#33)
        └── Support arbitrary tuples 👈🏻
```