### PR TITLE
Allow `Relation<Key>` to join with `Variable<(Key, Value)>` directly

### DIFF
--- a/src/join.rs
+++ b/src/join.rs
@@ -210,9 +210,14 @@ impl<'me, Tuple: Ord> JoinInput<'me, (Tuple, ())> for &'me Relation<Tuple> {
         assert_eq!(mem::align_of::<(Tuple, ())>(), mem::align_of::<Tuple>());
 
         // SAFETY: https://rust-lang.github.io/unsafe-code-guidelines/layout/structs-and-tuples.html#structs-with-1-zst-fields
-        // guarantees that `T` is layout compatible with `(T, ())`, since `()` is a 1-ZST.
+        // guarantees that `T` is layout compatible with `(T, ())`, since `()` is a 1-ZST. We use
+        // `slice::from_raw_parts` because the layout compatibility guarantee does not extend to
+        // containers like `&[T]`.
         let elements: &'me [Tuple] = self.elements.as_slice();
-        let elements: &'me [(Tuple, ())] = unsafe { std::mem::transmute(elements) };
+        let len = elements.len();
+
+        let elements: &'me [(Tuple, ())] =
+            unsafe { std::slice::from_raw_parts(elements.as_ptr() as *const _, len) };
 
         f(elements)
     }

--- a/src/join.rs
+++ b/src/join.rs
@@ -51,13 +51,13 @@ fn join_delta<'me, Key: Ord, Val1: Ord, Val2: Ord>(
     let recent1 = input1.recent();
     let recent2 = input2.recent();
 
-    for batch2 in input2.stable().iter() {
+    input2.for_each_stable_set(|batch2| {
         join_helper(&recent1, &batch2, &mut result);
-    }
+    });
 
-    for batch1 in input1.stable().iter() {
+    input1.for_each_stable_set(|batch1| {
         join_helper(&batch1, &recent2, &mut result);
-    }
+    });
 
     join_helper(&recent1, &recent2, &mut result);
 }
@@ -164,40 +164,56 @@ pub trait JoinInput<'me, Tuple: Ord>: Copy {
     /// empty slice.)
     type RecentTuples: Deref<Target = [Tuple]>;
 
-    /// If we are on iteration N of the loop, these are the tuples
-    /// added on iteration N - 2 or before. (For a `Relation`, this is
-    /// just `self`.)
-    type StableTuples: Deref<Target = [Relation<Tuple>]>;
-
     /// Get the set of recent tuples.
     fn recent(self) -> Self::RecentTuples;
 
-    /// Get the set of stable tuples.
-    fn stable(self) -> Self::StableTuples;
+    /// Call a function for each set of stable tuples.
+    fn for_each_stable_set(self, f: impl FnMut(&[Tuple]));
 }
 
 impl<'me, Tuple: Ord> JoinInput<'me, Tuple> for &'me Variable<Tuple> {
     type RecentTuples = Ref<'me, [Tuple]>;
-    type StableTuples = Ref<'me, [Relation<Tuple>]>;
 
     fn recent(self) -> Self::RecentTuples {
         Ref::map(self.recent.borrow(), |r| &r.elements[..])
     }
 
-    fn stable(self) -> Self::StableTuples {
-        Ref::map(self.stable.borrow(), |v| &v[..])
+    fn for_each_stable_set(self, mut f: impl FnMut(&[Tuple])) {
+        for stable in self.stable.borrow().iter() {
+            f(stable)
+        }
     }
 }
 
 impl<'me, Tuple: Ord> JoinInput<'me, Tuple> for &'me Relation<Tuple> {
     type RecentTuples = &'me [Tuple];
-    type StableTuples = &'me [Relation<Tuple>];
 
     fn recent(self) -> Self::RecentTuples {
         &[]
     }
 
-    fn stable(self) -> Self::StableTuples {
-        std::slice::from_ref(self)
+    fn for_each_stable_set(self, mut f: impl FnMut(&[Tuple])) {
+        f(&self.elements)
+    }
+}
+
+impl<'me, Tuple: Ord> JoinInput<'me, (Tuple, ())> for &'me Relation<Tuple> {
+    type RecentTuples = &'me [(Tuple, ())];
+
+    fn recent(self) -> Self::RecentTuples {
+        &[]
+    }
+
+    fn for_each_stable_set(self, mut f: impl FnMut(&[(Tuple, ())])) {
+        use std::mem;
+        assert_eq!(mem::size_of::<(Tuple, ())>(), mem::size_of::<Tuple>());
+        assert_eq!(mem::align_of::<(Tuple, ())>(), mem::align_of::<Tuple>());
+
+        // SAFETY: https://rust-lang.github.io/unsafe-code-guidelines/layout/structs-and-tuples.html#structs-with-1-zst-fields
+        // guarantees that `T` is layout compatible with `(T, ())`, since `()` is a 1-ZST.
+        let elements: &'me [Tuple] = self.elements.as_slice();
+        let elements: &'me [(Tuple, ())] = unsafe { std::mem::transmute(elements) };
+
+        f(elements)
     }
 }


### PR DESCRIPTION
Polonius has to create new intermediate variables with types like `Variable<(Key, ())>` from `Relation<Key>` so that they can be joined with variables like `Variable<(Key, Value)>`. This happens once in the naive variant ([see below](
https://github.com/rust-lang/polonius/blob/741e6095fe50f468982d4d253e842eb7d12ed9d3/polonius-engine/src/output/naive.rs#L60-L85)) and twice in the optimized one. This isn't actually necessary, since we can legally transmute a `Relation<Key>` to a `Relation<(Key, ())>` according to the unsafe-code guidelines. This saves a bit of memory and some time copying tuples around, although these relations aren't very large on any of the inputs bundled with Polonius. Mostly, it makes the code clearer by removing the number of variables used solely for re-indexing.

~~To do this safely, I had to change how `Relation` implements `JoinInput`. This actually fixes a bug in `Relation::from_antijoin` (which we don't use), but it's not obviously correct. See the second commit for details.~~

I changed the signature of `JoinInput` so its semantics could remain the same. `Relation::from_antijoin` is still broken, however.