### PR TITLE
Add a helper function for "passthrough" leapers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use crate::{
         extend_with::ExtendWith,
         filter_anti::FilterAnti,
         filter_with::FilterWith,
-        filters::{PrefixFilter, ValueFilter},
+        filters::{passthrough, PrefixFilter, ValueFilter},
         Leaper, Leapers, RelationLeaper,
     },
     variable::Variable,


### PR DESCRIPTION
See https://github.com/rust-lang/polonius/pull/178#issuecomment-901315380 for background. This is a simple way to combine rules 7 and 8 of the naive analysis. I haven't audited the other rulesets to see where it could be used.

Frankly, this seems a little too cute to me. The fact that you need this esoteric thing to avoid a runtime panic is not good API design. At the very least, we should try to make the "no proposers" case panic at compile-time, but that's easier said than done.

r? @lqd 