### PR TITLE
Migrate containers from `Vec<(Tuple)>` to columnar containers

### DIFF
--- a/src/relation.rs
+++ b/src/relation.rs
@@ -38,7 +38,7 @@ impl<Tuple: Ord> Relation<Tuple> {
     /// see [`Variable::from_leapjoin`](crate::Variable::from_leapjoin)
     pub fn from_leapjoin<'leap, SourceTuple: Ord, Val: Ord + 'leap>(
         source: &Relation<SourceTuple>,
-        leapers: impl Leapers<'leap, SourceTuple, Val>,
+        leapers: impl Leapers<SourceTuple, &'leap Val>,
         logic: impl FnMut(&SourceTuple, &Val) -> Tuple,
     ) -> Self {
         treefrog::leapjoin(&source.elements, leapers, logic)

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -264,7 +264,7 @@ impl<Tuple: Ord> Variable<Tuple> {
     pub fn from_leapjoin<'leap, SourceTuple: Ord, Val: Ord + 'leap>(
         &self,
         source: &Variable<SourceTuple>,
-        leapers: impl Leapers<'leap, SourceTuple, Val>,
+        leapers: impl Leapers<SourceTuple, &'leap Val>,
         logic: impl FnMut(&SourceTuple, &Val) -> Tuple,
     ) {
         self.insert(treefrog::leapjoin(&source.recent.borrow(), leapers, logic));


### PR DESCRIPTION
The `Relation<Tuple>` type wraps a `Vec<Tuple>` that is sorted and deduplicated. This is great, except for the opinion that it must be a `Vec<Tuple>`. This is a stronger opinion about the layout of the data than we require. By constrast, the [`columnar`](https://crates.io/crates/columnar) crate is able to lay out sequences of structured types using large allocations of simple types. There are a few advantages here:
1. Non-`Copy` types become less painful. Strings, JSON, other non-trivial types avoid allocating all over the place and inducing lots of random accesses.
2. Containers for `(Key, Val)` segregate the key information, which makes searching for keys that much easier. Only key data are brought in, and various forms of compression (e.g. run-length, for sorted data) can make the data that much smaller. Merging and matching keys is often a large source of work.
3. Reshaping containers is easy. The container for a k-tuple `(A, B, C, .. K)` is a k-tuple of containers, and one can reshape it into a container for `((A, B), (C, .. K))` at essentially no cost. This allows a sorted list of tuples to be treated as a trie, and serve as indexes for any prefix of the sorted list. This avoids needing e.g. separate indexes for a `(A, B)` collection on each of `()`, `(A)`, and `(A, B)`. You'd need them on `B` and `(B, A)` separately, but that would only be one additional relation/variable as well.